### PR TITLE
Change shebang as scripts are not POSIX-compliant

### DIFF
--- a/.github/actions/test/test.sh
+++ b/.github/actions/test/test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Usage: `bash test.sh` (only supported shell for this script is bash)
 

--- a/ddexec.sh
+++ b/ddexec.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 filename=/bin/dd
 

--- a/ddsc.sh
+++ b/ddsc.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 filename=/bin/dd
 


### PR DESCRIPTION
By setting `/bin/sh` as the shebang, you declare that the script is POSIX-compliant. However, this is not the case.

As a consequence, this script would not run on distributions (such as Debian) who do not symlink `/bin/sh` to `/bin/bash` if executed using `./ddexec.sh`.

Therefore, I think `/bin/bash` is more appropriate here.

References: 
* [SC2039](https://github.com/koalaman/shellcheck/wiki/SC2039)
* [Bashims](https://mywiki.wooledge.org/Bashism)