### PR TITLE
Initial linting of ddexec.sh 

### DIFF
--- a/ddexec.sh
+++ b/ddexec.sh
@@ -536,22 +536,16 @@ ddexec()
     # Arguments' format for the chosen seeker
     if [ -z "$SEEKER_ARGS" ]
     then
-        if [ $(basename $seeker) = "tail" ]
-        then
-            SEEKER_ARGS='-c +$(($offset + 1))'
-        elif   [ $(basename $seeker) = "dd" ]
-        then
-            SEEKER_ARGS='bs=1 skip=$offset'
-        elif [ $(basename $seeker) = "hexdump" ]
-        then
-            SEEKER_ARGS='-s $offset'
-        elif [ $(basename $seeker) = "cmp" ]
-        then
-            SEEKER_ARGS='-i $offset /dev/null'
-        else
+        case "$(basename $seeker)" in
+        tail) SEEKER_ARGS='-c +$(($offset + 1))';;
+        dd) SEEKER_ARGS='bs=1 skip=$offset';;
+        hexdump) SEEKER_ARGS='-s $offset';;
+        cmp) SEEKER_ARGS='-i $offset /dev/null';;
+        *) 
             echo "DDexec: Unknown seeker. Provide its arguments in SEEKER_ARGS."
             exit 1
-        fi
+            ;;
+        esac
     fi
 
     # Overwrite vDSO with our shellcode

--- a/ddexec.sh
+++ b/ddexec.sh
@@ -1,4 +1,3 @@
-#!/bin/sh
 
 # Prepend the shellcode with an infinite loop (so you can attach to it with gdb)
 # Then in gdb just use `set $pc+=2' and you will be able to `si'.
@@ -442,6 +441,9 @@ else
 fi
 
 # Program we are trying to run
+# -- unset it first, in case the user exported this variable,
+# -- to avoid "argumnent list too long" error on env copy
+unset bin
 read -r bin
 
 shell=$(readlink -f /proc/$$/exe)

--- a/ddexec.sh
+++ b/ddexec.sh
@@ -3,14 +3,14 @@
 # Prepend the shellcode with an infinite loop (so you can attach to it with gdb)
 # Then in gdb just use `set $pc+=2' and you will be able to `si'.
 # In ARM64 use `set $pc+=4'.
-if [ -z "$DEBUG" ]; then DEBUG=0; fi
+: "${DEBUG:=0}"
 
 # If the seeker binary is not executable by your user, you may try to run it
 # through the loader (typically ld.so).
-if [ -z "$USE_INTERP" ]; then USE_INTERP=0; fi
+: "${USE_INTERP:=0}"
 
 # Currently tail is the default binary used to lseek() through the mem file.
-if [ -z "$SEEKER" ]; then seeker=tail; else seeker="$SEEKER"; fi
+: "${SEEKER:=tail}"
 
 # Endian conversion
 endian()
@@ -454,6 +454,7 @@ ddexec()
     fi
 
     # Seeker command for searching RAM (tail)
+    seeker=$SEEKER
     seeker=$(command -v "$seeker") # Harry Potter vibes? Nah.
     realname=$(basename $(readlink -f $seeker))
     if [ -z ${realname##*box*} ] # Busybox / Toybox

--- a/ddexec.sh
+++ b/ddexec.sh
@@ -475,7 +475,7 @@ ddexec()
     if [ $USE_INTERP -eq 1 ]
     then
         interp_off=$(search_section file $seeker .interp)
-        if [ -n "interp_off" ]
+        if [ -n "$interp_off" ]
         then
             interp_size=$(echo $interp_off | cut -d' ' -f2)
             interp_off=$(echo $interp_off | cut -d' ' -f1)


### PR DESCRIPTION
Hi @arget13,

It works super fine, nice script. 
I refactored a little, with the function declaration and docstring my style so that I can have a nice folding, I hope this is OK for you.

Otherwise, there are 2 minors improvement:

1. `if [ -n "interp_off" ]`  (forgot the dollar)
2. `bin` variable is exported in my environment, so I get an "argument list too long" because this variable becomes very big and is passed (in my case as exported)

But most of all these are the changes:
* [X] Quote expansions
* [X] Use the default assignment idioms :=
* [X] Nest all in function from top to bottom, create a main


### Folding

The folding I get with docstrings inside functions, for reference

```
    1 #!/bin/sh
    2
    3 init_global(){                                                  : 'Init global variables                                                         > 64
   67 endian(){                                                       : 'Helper: Endian conversion'                                                     > 6
   73 sc_chunk(){                                                     : 'Exctract a chunk from the global SC_ARRAY'                                     > 6
   79 search_section(){                                               : 'Search for a section segment in file                                          > 87
  166 shellcode_loader(){                                             : '### TODO: SHF_COMPRESSED sections ###                                        > 158
  324 craft_stack(){                                                  : 'Craft initial stack                                                           > 75
  399 craft_shellcode(){                                              : 'Craft the shellcode to bootload user binary'                                  > 56
  455 ddexec(){                                                       : 'Main function'                                                               > 133
  588 ddexec "$@"
  ```