### PR TITLE
CI: Improve GTA with matrix tests on X84 and ARM: shell x image

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -1,7 +1,15 @@
+---
 name: 'Testing...'
 description: 'Runs a bunch of tests'
+
+inputs:
+  shell:
+    description: "Executable name of the shell to use"
+    required: false
+    default: bash
+
 runs:
-  using: "composite"
+  using: composite
   steps:
-    - run: bash .github/actions/test/test.sh
+    - run: bash .github/actions/test/test.sh ${{ inputs.shell }}
       shell: bash

--- a/.github/actions/test/test.sh
+++ b/.github/actions/test/test.sh
@@ -2,119 +2,42 @@
 
 # Usage: `bash test.sh` (only supported shell for this script is bash)
 
-status=0
+# TODO
+# Add function equal with color for report
 
-sc="4831ff5766ffc748b86f20776f726c640a50b848656c6c48c1e02050488"\
+exit_status=0
+
+shellcode_base64="4831ff5766ffc748b86f20776f726c640a50b848656c6c48c1e02050488"\
 "9e64883c6044889f84889c2b20c0f054831c04889c7b03c0f05"
-sc_bin=$(echo -n $sc | sed 's/\([0-9A-F]\{2\}\)/\\x\1/gI')
+shellcode_binary=$(printf "%s" "$shellcode_base64" | sed 's/\([0-9A-F]\{2\}\)/\\x\1/gI')
 
-time r="$(base64 -w0 `which echo` |\
-     bash ddexec.sh echo -n asd qwerty "" zxcvb " fdsa gf")"
-if [ "$r" = "$(echo -n asd qwerty "" zxcvb " fdsa gf")" ]
-then
-    echo "bash + ddexec, test 1: OK"
-else
-    echo "bash + ddexec, test 1: Error :("
-    status=1
-fi
-time r="$(base64 -w0 `which echo` |\
-     bash ddexec.sh echo -n asd qwerty "" zxcvb " fdsa gf" .)"
-if [ "$r" = "$(echo -n asd qwerty "" zxcvb " fdsa gf" .)" ]
-then
-    echo "bash + ddexec, test 2: OK"
-else
-    echo "bash + ddexec, test 2: Error :("
-    status=1
-fi
-time r=$(echo $sc | bash ddsc.sh -x)
-if [ "$r" = "Hello world" ]
-then
-    echo "bash + ddsc, test 1: OK"
-else
-    echo "bash + ddsc, test 1: Error :("
-    status=1
-fi
-time r=$(printf "$sc_bin" | bash ddsc.sh)
-if [ "$r" = "Hello world" ]
-then
-    echo "bash + ddsc, test 2: OK"
-else
-    echo "bash + ddsc, test 2: Error :("
-    status=1
-fi
-echo
+equal(){
+    : 'Helper function
+      Ex: equal 0 0 "yes it works"
+    '
+    local msg=''
+    if [ "$1" = "$2" ]; then
+      msg="\e[32mSUCCESS: $3\e[0m: (got '$1')"
+    else
+      exit_status=1
+      msg="\e[31mERROR  : $3\e[0m: (expected '$1' and got '$2')"
+    fi
+    echo -e "$msg"
+}
 
-time r="$(base64 -w0 `which echo` |\
-     zsh ddexec.sh echo -n asd qwerty "" zxcvb " fdsa gf")"
-if [ "$r" = "$(echo -n asd qwerty "" zxcvb " fdsa gf")" ]
-then
-    echo "zsh + ddexec, test 1: OK"
-else
-    echo "zsh + ddexec, test 1: Error :("
-    status=1
-fi
-time r="$(base64 -w0 `which echo` |\
-     zsh ddexec.sh echo -n asd qwerty "" zxcvb " fdsa gf" .)"
-if [ "$r" = "$(echo -n asd qwerty "" zxcvb " fdsa gf" .)" ]
-then
-    echo "zsh + ddexec, test 2: OK"
-else
-    echo "zsh + ddexec, test 2: Error :("
-    status=1
-fi
-time r=$(echo $sc | zsh ddsc.sh -x)
-if [ "$r" = "Hello world" ]
-then
-    echo "zsh + ddsc, test 1: OK"
-else
-    echo "zsh + ddsc, test 1: Error :("
-    status=1
-fi
-time r=$(printf "$sc_bin" | zsh ddsc.sh)
-if [ "$r" = "Hello world" ]
-then
-    echo "zsh + ddsc, test 2: OK"
-else
-    echo "zsh + ddsc, test 2: Error :("
-    status=1
-fi
-echo
+equal 0 0 "Testing equal function primitive"
 
-if [ "$1" = "noash" ]; then exit $status; fi
+# DDexec echo
+ret=$(base64 -w0 "$(which echo)" |\
+     "$1" ddexec.sh echo -n asd qwerty "" zxcvb " fdsa gf")
+equal "$(echo -n asd qwerty "" zxcvb " fdsa gf")" "$ret" "bash + ddexec, test 1"
 
-time r="$(base64 -w0 `which echo` |\
-     ash ddexec.sh echo -n asd qwerty "" zxcvb " fdsa gf")"
-if [ "$r" = "$(echo -n asd qwerty "" zxcvb " fdsa gf")" ]
-then
-    echo "ash + ddexec, test 1: OK"
-else
-    echo "ash + ddexec, test 1: Error :("
-    status=1
-fi
-time r="$(base64 -w0 `which echo` |\
-     ash ddexec.sh echo -n asd qwerty "" zxcvb " fdsa gf" .)"
-if [ "$r" = "$(echo -n asd qwerty "" zxcvb " fdsa gf" .)" ]
-then
-    echo "ash + ddexec, test 2: OK"
-else
-    echo "ash + ddexec, test 2: Error :("
-    status=1
-fi
-time r=$(echo $sc | ash ddsc.sh -x)
-if [ "$r" = "Hello world" ]
-then
-    echo "ash + ddsc, test 1: OK"
-else
-    echo "ash + ddsc, test 1: Error :("
-    status=1
-fi
-time r=$(printf "$sc_bin" | ash ddsc.sh)
-if [ "$r" = "Hello world" ]
-then
-    echo "ash + ddsc, test 2: OK"
-else
-    echo "ash + ddsc, test 2: Error :("
-    status=1
-fi
+# DDsc shellcode
+ret=$(echo $shellcode_base64 | "$1" ddsc.sh -x)
+equal "Hello world" "$ret" "bash + ddsc, test 1"
 
-exit $status
+# DDsc shellcode bin
+ret=$(printf "$shellcode_binary" | "$1" ./ddsc.sh)
+equal "Hello world" "$ret" "bash + ddsc, test 2"
+
+exit "$exit_status"

--- a/.github/workflows/arm.yml
+++ b/.github/workflows/arm.yml
@@ -1,5 +1,7 @@
-name: CI
+---
+name: "CI ARM"
 
+# yamllint disable-line rule:truthy
 on:
   push:
     paths-ignore:
@@ -8,41 +10,48 @@ on:
   pull_request:
     paths-ignore:
       - '*.md'
-      
+
   workflow_dispatch:
     paths-ignore:
       - '*.md'
 
 jobs:
-  alpine_arm64:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: uraimo/run-on-arch-action@v2
-        with:
-          arch: aarch64
-          distro: alpine_latest
-          run: apk update && apk add bash zsh
-      - uses: ./.github/actions/test
+  arm:
+    name: "ARM64: ${{ matrix.shell }} on ${{ matrix.image }}"
+    strategy:
+      fail-fast: false
+      matrix:
+        shell: [bash, zsh]  # Currently no ash
+        image: [alpine, debian, archlinux]
 
-  debian_arm64:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: uraimo/run-on-arch-action@v2
-        with:
-          arch: aarch64
-          distro: bullseye
-          run: apt-get update && apt-get install -y busybox zsh && ln -sf /bin/busybox /bin/ash
-      - uses: ./.github/actions/test
+    env:
+      json-map: '{"alpine": "alpine_latest", "debian": "bullseye", "archlinux": "archarm_latest"}'
 
-  arch_arm64:
     runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v3
-      - uses: uraimo/run-on-arch-action@v2
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: "Install for ${{ matrix.image }}"
+        uses: uraimo/run-on-arch-action@v2
         with:
           arch: aarch64
-          distro: archarm_latest
-          run: pacman -Sy --noconfirm busybox zsh which && ln -sf /bin/busybox /bin/ash
-      - uses: ./.github/actions/test
+          distro: ${{ fromJSON( env.json-map )[matrix.image] }}
+          run: |
+            case "${{ matrix.image }}" in
+              alpine)
+                apk update
+                apk add bash zsh
+                ;;
+              debian)
+                apt-get update
+                apt-get install -y busybox zsh
+                ln -sf /bin/busybox /bin/ash
+                ;;
+              archlinux)
+                pacman -Sy --noconfirm busybox zsh which
+                ln -sf /bin/busybox /bin/ash
+                ;;
+            esac
+            ${{ matrix.shell }} ./.github/actions/test/test.sh ${{ matrix.shell }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,8 @@
-name: CI
+---
 
+name: "CI X64"
+
+# yamllint disable-line rule:truthy
 on:
   push:
     paths-ignore:
@@ -8,39 +11,46 @@ on:
   pull_request:
     paths-ignore:
       - '*.md'
-      
+
   workflow_dispatch:
     paths-ignore:
       - '*.md'
 
 jobs:
-  alpine_x64:
-    container:
-      image: alpine
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - run: apk update && apk add bash zsh
-      - uses: ./.github/actions/test ash
+  main:
+    name: "X86: ${{ matrix.shell }} on ${{ matrix.image }}"
+    strategy:
+      fail-fast: false
+      matrix:
+        shell: [bash, zsh]  # Currently no ash
+        image: [alpine, debian, archlinux]
 
-  debian_x64:
     container:
-      image: debian
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      # - run: apt-get update && apt-get install -y busybox zsh
-      - run: apt-get update && apt-get install -y zsh
-      # - run: ln -sf /bin/busybox /bin/ash
-      - uses: ./.github/actions/test
+      image: ${{ matrix.image }}
 
-  arch_x64:
-    container:
-      image: archlinux
     runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v3
-      # - run: pacman -Sy --noconfirm busybox zsh which
-      - run: pacman -Sy --noconfirm zsh which
-      # - run: ln -sf /bin/busybox /bin/ash
-      - uses: ./.github/actions/test
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install
+        run: |
+          case "${{ matrix.image }}" in
+            alpine)
+              apk update
+              apk add which bash ${{ matrix.shell }}
+              ;;
+            debian)
+              apt-get update
+              apt-get install -y ${{ matrix.shell }}
+              ;;
+            archlinux)
+              pacman -Sy --noconfirm which ${{ matrix.shell }}
+              ;;
+          esac
+
+      - name: Run
+        uses: ./.github/actions/test
+        with:
+          shell: ${{ matrix.shell }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 # DDexec
+
+[![CI: X64](https://github.com/arget13/DDexec/workflows/CI%20X64/badge.svg)](https://github.com/arget13/DDexec/actions/workflows/main.yml)
+[![CI: ARM](https://github.com/arget13/DDexec/workflows/CI%20ARM/badge.svg)](https://github.com/arget13/DDexec/actions/workflows/arm.yml)
+
 ## Context
 In Linux in order to run a program it must exist as a file, it must be accessible in some way through the file system hierarchy (this is just how `execve()` works). This file may reside on disk or in ram (tmpfs, memfd) but you need a filepath. This has made very easy to control what is run on a Linux system, it makes easy to detect threats and attacker's tools or to prevent them from trying to execute anything of theirs at all (_e. g._ not allowing unprivileged users to place executable files anywhere).
 


### PR DESCRIPTION
I worked a little on github actions for them to use a matrix strategy.

The ARM file is still independant as it is using another remote action (it would be nice to have CPU in a matrix field but I did not take the time to make this "conditional use of subaction").

It looks like that on [my repo](https://github.com/tinmarino/DDexec/tree/3034e50b7539df5d2cb895f462493fee19e0ec58), also see the [Action output](https://github.com/tinmarino/DDexec/actions). But the last commit is changing the image URL to point to this root repo => ready to merge.

![Screenshot from 2023-04-16 15-51-38](https://user-images.githubusercontent.com/6123962/232338854-79b6d712-9b99-447f-93a3-a160842dc1d5.png)